### PR TITLE
Prevent javascript error at postTest

### DIFF
--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -1,7 +1,7 @@
 var MockService = {
     reset: function() {
         if (this.browser) {
-            this.browser.executeScript("window.MockManager.reset();");
+            this.browser.executeScript("if(window.hasOwnProperty('MockManager')) window.MockManager.reset();");
         }
         this.browser = null;
         this.queue = [];


### PR DESCRIPTION
Prevent javascript error at postTest when the plugin hasn't been properly initialized.