### PR TITLE
Make usage standard and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,24 @@
 # protractor-xmlhttprequest-mock
 Ajax calls mocking plugin for protractor, will work with angular 2 also.
 
-For now there is no documentation, but there are some sample tests in `tests` folder.
+A simple example of usage:
+
+```ts
+import {browser, $} from 'protractor';
+import {MockService} from 'protractor-xmlhttprequest-mock';
+
+describe('the backend', () => {
+  it('should reply with code 418', () => {
+    MockService.setup(browser);
+    MockService.addMock('mock1', {
+      path: '/api/teapot',
+      response: {status: 418, data: "I'm a teapot"},
+    });
+
+    $('button').click();
+    expect($('div').getText()).toEqual("I'm a teapot");
+  });
+});
+```
+
+Other examples can be found in `tests` folder.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,6 @@
-var fs = require('fs'),
-	path = require('path'),
-    MockService = require('./mock-service').MockService;
-
-// load scripts from files
-var scripts = "";
-scripts += fs.readFileSync(path.join(__dirname, './browser-scripts/XMLHttpRequestMock.js'), 'utf-8');
-scripts += fs.readFileSync(path.join(__dirname, './browser-scripts/MockManager.js'), 'utf-8');
+var MockService = require('./mock-service').MockService;
 
 exports.onPageLoad = function () {
-    // inject script in browser after page load
-    //console.log('setup');
-    browser.executeScript(
-        scripts + "MockManager.setup();"
-    );
     MockService.setup(browser);
 };
 

--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -1,3 +1,6 @@
+var fs = require('fs'),
+    path = require('path');
+
 var MockService = {
     reset: function() {
         if (this.browser) {
@@ -9,16 +12,31 @@ var MockService = {
 
     setup: function(browser) {
         this.browser = browser;
-        if (this.queue) {
-            //console.log('Execute scripts from queue: ');
-            this.queue.forEach(function (script) {
-                //console.log(script);
-                this.browser.executeScript(script);
-            });
-            //console.log('DONE');
-            this.queue = [];
-        }
-        this.browser.executeScript("if (window.bootApp) window.bootApp();");
+
+        // Inject browser scripts if needed
+        return browser.executeScript('return typeof MockService == "undefined"')
+        .then(function (needed) {
+            if (needed) {
+                var scripts = "";
+                scripts += fs.readFileSync(path.join(
+                    __dirname, './browser-scripts/XMLHttpRequestMock.js'), 'utf-8');
+                scripts += fs.readFileSync(path.join(
+                    __dirname, './browser-scripts/MockManager.js'), 'utf-8');
+
+                browser.executeScript(scripts + 'MockManager.setup();');
+            }
+
+            if (this.queue) {
+                //console.log('Execute scripts from queue: ');
+                this.queue.forEach(function (script) {
+                    //console.log(script);
+                    this.browser.executeScript(script);
+                });
+                //console.log('DONE');
+                this.queue = [];
+            }
+            this.browser.executeScript("if (window.bootApp) window.bootApp();");
+        });
     },
 
     addMock: function(name, config) {


### PR DESCRIPTION
#### Inject browser scripts when needed

Inject browser scripts in the `MockService.setup()` function, but only
if they are needed. This way, it is easy to install the `MockService`
and we don't have to rely on `onPageLoad()` from `lib/index.js` (which
isn't called in most environments).

It is now possible to use protractor-xmlhttprequest-mock like this:

```ts
import {browser, $} from 'protractor';
import {MockService} from 'protractor-xmlhttprequest-mock';

describe('the backend', () => {
  it('should reply with code 418', () => {
    MockService.setup(browser);
    MockService.addMock('mock1', {
      path: '/api/teapot',
      response: {status: 418, data: "I'm a teapot"},
    });

    $('button').click();
    expect($('div').getText()).toEqual("I'm a teapot");
  });
});
```

---

#### Documentation: Add an example of usage in the README
