### PR TITLE
Allow {status: 0} in mock response

### DIFF
--- a/lib/browser-scripts/XMLHttpRequestMock.js
+++ b/lib/browser-scripts/XMLHttpRequestMock.js
@@ -41,7 +41,7 @@ class XMLHttpRequestMock extends XMLHttpRequest {
     }
 
     getStatus() {
-        return this._status || super.status;
+        return typeof this._status === 'number' ? this._status : super.status;
     }
 
     getResponse() {


### PR DESCRIPTION
`0` is the code returned in case of network error. The following can be used to simulate one, for instance a connection refused:

```ts
MockService.addMock('mock', {
  path: '/',
  response: {status: 0, data: ''},
});
```

Before this commit it was not possible because of `this._status || super.status` and generated an infinite loop in the browser:

    Uncaught RangeError: Maximum call stack size exceeded
        at XMLHttpRequest.get (<anonymous>:435:18)
        at XMLHttpRequest.getStatus (<anonymous>:415:32)
        at XMLHttpRequest.get (<anonymous>:436:21)
        at XMLHttpRequest.getStatus (<anonymous>:415:32)
        at XMLHttpRequest.get (<anonymous>:436:21)
        at XMLHttpRequest.getStatus (<anonymous>:415:32)
        ...