### PR TITLE
Fix browser scripts injection

### DIFF
--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -16,7 +16,7 @@ var MockService = {
         var self = this;
 
         // Inject browser scripts if needed
-        return browser.executeScript('return typeof MockService == "undefined"')
+        return browser.executeScript('return typeof MockManager == "undefined"')
         .then(function (needed) {
             if (needed) {
                 //console.log('injecting mock service!');


### PR DESCRIPTION
This fixes a bug introduced by commit 5e61f3b: the mock object that
lives inside the browser is `MockManager`, not `MockService` (the latter
lives in the test process).

I'm sorry I wasn't careful enough when writing the original commit :/