### PR TITLE
Support for promise chaining and async/await

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,11 @@
 var MockService = require('./mock-service').MockService;
 
 exports.onPageLoad = function () {
-    MockService.setup(browser);
+    return MockService.setup(browser);
 };
 
 exports.postTest = function () {
-    MockService.reset();
+    return MockService.reset();
 };
 
 exports.MockService = MockService;

--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -3,11 +3,16 @@ var fs = require('fs'),
 
 var MockService = {
     reset: function() {
-        if (this.browser) {
-            this.browser.executeScript("if(window.hasOwnProperty('MockManager')) window.MockManager.reset();");
-        }
-        this.browser = null;
-        this.queue = [];
+        return new Promise((resolve, reject) => {
+            if (this.browser) {
+                this.browser.executeScript("if(window.hasOwnProperty('MockManager')) window.MockManager.reset();")
+                    .then(resolve);
+                return;
+            }
+            this.browser = null;
+            this.queue = [];
+            resolve();
+        });
     },
 
     setup: function(browser) {
@@ -18,28 +23,29 @@ var MockService = {
         // Inject browser scripts if needed
         return browser.executeScript('return typeof MockManager == "undefined"')
         .then(function (needed) {
+            var scripts = "";
             if (needed) {
                 //console.log('injecting mock service!');
-                var scripts = "";
                 scripts += fs.readFileSync(path.join(
                     __dirname, './browser-scripts/XMLHttpRequestMock.js'), 'utf-8');
                 scripts += fs.readFileSync(path.join(
                     __dirname, './browser-scripts/MockManager.js'), 'utf-8');
 
-                browser.executeScript(scripts + 'MockManager.setup();');
+                scripts += 'MockManager.setup();'
             }
 
             //console.log('check the queue', this.queue);
             if (self.queue) {
                 //console.log('Execute scripts from queue: ');
                 self.queue.forEach(function (script) {
+                    scripts += script + ';';
                     //console.log(script);
-                    browser.executeScript(script);
                 });
                 //console.log('DONE');
                 self.queue = [];
             }
-            this.browser.executeScript("if (window.bootApp) window.bootApp();");
+            scripts += "if (window.bootApp) window.bootApp();";
+            return browser.executeScript(scripts);
         });
     },
 
@@ -55,10 +61,11 @@ var MockService = {
         //console.log('add mock browser instance', this.browser);
         if (this.browser) {
             //console.log('Execute script in browser: ', script, this.browser);
-            this.browser.executeScript(script);
+            return this.browser.executeScript(script);
         } else {
             //console.log('Put script in queue for execution: ', script);
             this.queue.push(script);
+            return new Promise((resolve, reject) => resolve());
         }
         
     }


### PR DESCRIPTION
The WebDriver control flow [is deprecated](https://github.com/SeleniumHQ/selenium/issues/2969) and [planned to be removed from Protractor](https://github.com/angular/protractor/issues/3990). The new way of the world is to use promise chaining or `async`/`await`.

This PR adapts all of the mock service methods so that they return Promises. This will allow adding `.then` or `await` to these calls after the upgrade, while not making any changes to users that haven't made the switch yet.

If you're already off the control flow/promise manager, you can now do this:

```
MockService.setup(browser).then(function() {
    MockService.addMock('demo', {...}).then(function() {
        // Do something here
    });
});
```

Or this:

```
await MockService.setup(browser);
await MockService.addMock('demo', {...});
```

Again, if you are still using the deprecated version, everything will still work as normal.