### PR TITLE
Fix #17

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,13 @@
 import {ProtractorBrowser} from 'protractor';
 
 export declare interface MockConfig {
+    method?: string,
     path: string | RegExp,
     response: Response
 }
 
 export declare interface MultipleMockResponseConfig {
+    method?: string,
     path: string | RegExp,
     response: Response[]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import {ProtractorBrowser} from 'protractor';
 
 export declare interface MockConfig {
     path: string | RegExp,
-    response: Response | Response[]
+    response: Response
 }
 
 export declare interface MultipleMockResponseConfig {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,14 +2,22 @@ import {ProtractorBrowser} from 'protractor';
 
 export declare interface MockConfig {
     path: string | RegExp,
-    response: {
-        status: number,
-        data: string
-    }
+    response: Response | Response[]
+}
+
+export declare interface MultipleMockResponseConfig {
+    path: string | RegExp,
+    response: Response[]
+}
+
+export declare interface Response {
+    status: number,
+    data: string
 }
 
 export declare class MockService {
     static reset();
     static setup(browser: ProtractorBrowser);
     static addMock(name: string, config: MockConfig);
+    static addMocks(name: string, config: MultipleMockResponseConfig);
 }

--- a/lib/browser-scripts/MockManager.js
+++ b/lib/browser-scripts/MockManager.js
@@ -6,6 +6,7 @@ class MockManager {
         window.XMLHttpRequest = window.XMLHttpRequestMock;
         window.MockManager = MockManager;
         this.mocks = new Map();
+        this.mocksWithMultipleResponses = new Map();
         //console.log('mockManager.setup()');
     }
 
@@ -15,9 +16,10 @@ class MockManager {
 
     static reset() {
         this.mocks = new Map();
+        this.mocksWithMultipleResponses = new Map();
     }
 
-    static addMock(name, config) {
+    static sanitiseConfig(config) {
         config = JSON.parse(config);
         if (config && config.path && config.path.type) {
             switch(config.path.type) {
@@ -27,12 +29,42 @@ class MockManager {
                     break;
             }
         }
-        console.log('aad mock', name, config);
+        return config;
+    }
+
+    static addMock(name, config) {
+        config = this.sanitiseConfig(config);
+        console.log('add mock', name, config);
         this.mocks.set(name, config);
+    }
+
+    static addMocks(name, config) {
+        config = this.sanitiseConfig(config);
+        console.log('add mocks', name, config);
+        this.mocksWithMultipleResponses.set(name, config);
     }
 
     static getResponse(method, path) {
         let response = null;
+
+        //console.log(this.mocksWithMultipleResponses);
+        this.mocksWithMultipleResponses.forEach(function (config, name) {
+            let configPath = config.path instanceof RegExp ? config.path : new RegExp(config.path, 'i');
+            if (path.match(configPath)) {
+                if (!config.method || config.method && config.method.match(new RegExp(method, 'i'))) {
+                    if (config.response.length > 0) {
+                        const nextMock = config.response.shift();
+                        console.log("Return mock for", path, configPath, nextMock)
+                        response = nextMock;
+                    }
+                }
+            }
+        });
+
+        if (response) {
+            return response;
+        }
+
         //console.log(this.mocks);
         this.mocks.forEach(function (config, name) {
             let configPath  = config.path instanceof RegExp ? config.path : new RegExp(config.path,'i');

--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -1,6 +1,23 @@
 var fs = require('fs'),
     path = require('path');
 
+function sanitiseConfig(config) {
+    if (!(config.path instanceof RegExp)) {
+        return;
+    }
+
+    config.path = {
+        type: "RegExp",
+        params: [
+            config.path.toString()
+        ]
+    }
+}
+
+function stringifyConfig(config) {
+    return JSON.stringify(config).replace(/\\/gi, "\\\\").replace(/"/gi, "\\\"");
+}
+
 var MockService = {
     reset: function() {
         return new Promise((resolve) => {
@@ -44,35 +61,30 @@ var MockService = {
     },
 
     addMock: function(name, config) {
+        sanitiseConfig(config);
+        var script = `window.MockManager.addMock("${name}", "${stringifyConfig(config)}");`;
+        //console.log(script);
+        return this.runScript(script);
+    },
+
+    addMocks: function(name, config) {
+        sanitiseConfig(config);
+        var script = `window.MockManager.addMocks("${name}", "${stringifyConfig(config)}");`;
+        //console.log(script);
+        return this.runScript(script);
+    },
+
+    runScript: function (script) {
         if (!this.queue) {
             this.queue = [];
         }
-
-        if (config.path instanceof RegExp) {
-            // serialize regexp to be json friendly
-            config.path = {
-                type: "RegExp",
-                params: [
-                    config.path.toString()
-                ]
-            }
-        }
-
-        var script = "window.MockManager.addMock(\"" + name + "\", \"" + 
-            JSON.stringify(config).replace(/\\/gi, "\\\\").replace(/"/gi, "\\\"") + 
-            "\");";
-        //console.log(script);
-
         //console.log('add mock browser instance', this.browser);
         if (this.browser) {
-            //console.log('Execute script in browser: ', script, this.browser);
             return this.browser.executeScript(script);
-        } else {
-            //console.log('Put script in queue for execution: ', script);
-            this.queue.push(script);
-            return Promise.resolve();
-        }   
-    }
+        }
+        this.queue.push(script);
+        return Promise.resolve();
+    },
 };
 
 exports.MockService = MockService;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-xmlhttprequest-mock",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-xmlhttprequest-mock",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Ajax requests mock plugin for protractor (works with Angular >= 2 also)",
   "main": "lib/index.js",
   "scripts": {

--- a/tests/angular.spec.js
+++ b/tests/angular.spec.js
@@ -220,6 +220,32 @@ function runAngularTests(angularVersion, url) {
             expect(getPageTitleText()).toBe(`Angular ${singleMockResponse} app`);
         });
 
+        it('should return correct mock based on method', async() => {
+            const postResponse = "Response for POST";
+            const getResponse = "Response for GET";
+            await MockService.addMocks('POST mocks', {
+                method: 'POST',
+                path: '/api/sample.json',
+                response: [{
+                    status: 200,
+                    data: JSON.stringify({response: postResponse})
+                }, {
+                    status: 500,
+                    data: JSON.stringify({response: postResponse})
+                }]
+            });
+            await MockService.addMock('GET mocks', {
+                method: 'GET',
+                path: '/api/sample.json',
+                response: {
+                    status: 200,
+                    data: JSON.stringify({response: getResponse})
+                }
+            });
+            await loadPage();
+            expect(getPageTitleText()).toBe(`Angular ${getResponse} app`);
+        });
+
         //TODO: read mocks after navigating to external page
         //TODO: read mocks after navigating to a redirect page
     });

--- a/tests/angular.spec.js
+++ b/tests/angular.spec.js
@@ -158,8 +158,70 @@ function runAngularTests(angularVersion, url) {
             expect(getPageTitleText()).toBe(ANGULAR_SAMPLE_APP_TITLE);
         });
 
-        //TODO: readd mocks after navigating to external page
-        //TODO: readd mocks after navigating to a redirect page
+        it('should allow you to set and use multiple mock response', async () => {
+            const expectedFirstResponse = "First Response";
+            const expectedSecondResponse = "Second Response";
+            await MockService.addMocks('multi-mock', {
+                path: '/api/sample.json',
+                response: [{
+                    status: 200,
+                    data: JSON.stringify({response: expectedFirstResponse})
+                }, {
+                    status: 200,
+                    data: JSON.stringify({response: expectedSecondResponse})
+                }]
+            });
+            await loadPage();
+            expect(getPageTitleText()).toBe(`Angular ${expectedFirstResponse} app`);
+            await browser.element(by.css('button')).click();
+            expect(getPageTitleText()).toBe(`Angular ${expectedSecondResponse} app`);
+        });
+
+        it('should use multi mock responses before using single mock responses', async () => {
+            const multiMockResponse = "Multi mock response";
+            await MockService.addMock('single-mock', {
+                path: '/api/sample.json',
+                response: {
+                    status: 200,
+                    data: JSON.stringify({response: "Single mock response"})
+                }
+            });
+            await MockService.addMocks('multiple-mocks', {
+                path: '/api/sample.json',
+                response: [{
+                    status: 200,
+                    data: JSON.stringify({response: multiMockResponse})
+                }]
+            });
+            await loadPage();
+            expect(getPageTitleText()).toBe(`Angular ${multiMockResponse} app`);
+        });
+
+        it('should use single mock when there are no more multi mock responses', async() => {
+            const singleMockResponse = "Single mock response";
+            const multiMockResponse = "Multi mock response";
+            await MockService.addMock('single-mock', {
+                path: '/api/sample.json',
+                response: {
+                    status: 200,
+                    data: JSON.stringify({response: singleMockResponse})
+                }
+            });
+            await MockService.addMocks('multiple-mocks', {
+                path: '/api/sample.json',
+                response: [{
+                    status: 200,
+                    data: JSON.stringify({response: multiMockResponse})
+                }]
+            });
+            await loadPage();
+            expect(getPageTitleText()).toBe(`Angular ${multiMockResponse} app`);
+            await browser.element(by.css('button')).click();
+            expect(getPageTitleText()).toBe(`Angular ${singleMockResponse} app`);
+        });
+
+        //TODO: read mocks after navigating to external page
+        //TODO: read mocks after navigating to a redirect page
     });
 }
 


### PR DESCRIPTION
fix #17 

this pr allows for a user to set multiple mocked responses for a given path. if multiple mocked responses are set then they take priority over and single mock responses. Single mock responses are used when there are no more multi mocked responses left (See Tests)

I've also added in a fix for #19 by adding method as an optional property on the MockConfig interfaces