### PR TITLE
Make it easy to get network traffic

### DIFF
--- a/lib/browser-scripts/MockManager.js
+++ b/lib/browser-scripts/MockManager.js
@@ -6,6 +6,7 @@ class MockManager {
         window.XMLHttpRequest = window.XMLHttpRequestMock;
         window.MockManager = MockManager;
         this.mocks = new Map();
+        this.allTraffic = {};
         //console.log('mockManager.setup()');
     }
 
@@ -15,6 +16,10 @@ class MockManager {
 
     static reset() {
         this.mocks = new Map();
+    }
+
+    static resetTraffic() {
+        this.allTraffic = {};
     }
 
     static addMock(name, config) {
@@ -46,9 +51,9 @@ class MockManager {
             let configResponse = Array.isArray(config.response) ? config.response : [];
 
             if (
-                path.match(configPath) && 
-                configMethod === method.toLowerCase() && 
-                configResponse.length > 0 && 
+                path.match(configPath) &&
+                configMethod === method.toLowerCase() &&
+                configResponse.length > 0 &&
                 configResponse[0].numberOfRequests > 0
             ) {
                     //console.log("Return mock for", path, configPath, config.response);

--- a/lib/browser-scripts/XMLHttpRequestMock.js
+++ b/lib/browser-scripts/XMLHttpRequestMock.js
@@ -4,13 +4,17 @@ class XMLHttpRequestMock extends XMLHttpRequest {
         this.mockedRequest = false;
         this.mock = null;
         this.hash = Math.floor(Math.random() * 1000);
+        window.MockManager.allTraffic[this.hash] = {};
     }
 
     open(method, url, async, user, password) {
         if (async === undefined) {
             async = true;
         }
-    
+
+        window.MockManager.allTraffic[this.hash].method = method;
+        window.MockManager.allTraffic[this.hash].url = url;
+
         super.open(method, url, async, user, password);
         let response = window.MockManager.getResponse(method, url);
         if (response) {
@@ -20,10 +24,12 @@ class XMLHttpRequestMock extends XMLHttpRequest {
     }
 
     send(data) {
+        window.MockManager.allTraffic[this.hash].data = data;
+
         if (this.mockedRequest) {
             this.readyState = this.LOADING;
             if (this.onreadystatechange) this.onreadystatechange();
-            
+
             this.responseText = this.mock.data;
             this.response = this.mock.data;
             this.status = this.mock.status;
@@ -45,11 +51,15 @@ class XMLHttpRequestMock extends XMLHttpRequest {
     }
 
     getResponse() {
-        return this._response || super.response;
+        const response = this._response || super.response;
+        window.MockManager.allTraffic[this.hash].response = response;
+        return response;
     }
 
     getResponseText() {
-        return this._responseText || super.responseText;
+        const responseText = this._responseText || super.responseText;
+        window.MockManager.allTraffic[this.hash].responseText = responseText;
+        return responseText;
     }
 
     getReadyState() {
@@ -60,7 +70,7 @@ class XMLHttpRequestMock extends XMLHttpRequest {
 Object.defineProperty(XMLHttpRequestMock.prototype, 'status', {
     set:function(value){
         this._status = value;
-    }, 
+    },
     get: function(){
         return this.getStatus()
     }
@@ -69,7 +79,7 @@ Object.defineProperty(XMLHttpRequestMock.prototype, 'status', {
 Object.defineProperty(XMLHttpRequestMock.prototype, 'response', {
     set:function(value){
         this._response = value;
-    }, 
+    },
     get: function(){
         return this.getResponse()
     }
@@ -78,7 +88,7 @@ Object.defineProperty(XMLHttpRequestMock.prototype, 'response', {
 Object.defineProperty(XMLHttpRequestMock.prototype, 'responseText', {
     set:function(value){
         this._responseText = value;
-    }, 
+    },
     get: function(){
         return this.getResponseText()
     }
@@ -87,7 +97,7 @@ Object.defineProperty(XMLHttpRequestMock.prototype, 'responseText', {
 Object.defineProperty(XMLHttpRequestMock.prototype, 'readyState', {
     set:function(value){
         this._readyState = value;
-    }, 
+    },
     get: function(){
         return this.getReadyState()
     }

--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -79,7 +79,7 @@ var MockService = {
     },
 
     resetNetworkTraffic: function () {
-        browser.executeScript('window.MockManager.resetTraffic();');
+        return browser.executeScript('window.MockManager.resetTraffic();');
     }
 };
 

--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -72,6 +72,14 @@ var MockService = {
             this.queue.push(script);
             return Promise.resolve();
         }   
+    },
+
+    getNetworkTraffic: function() {
+        return browser.executeScript('return MockManager.allTraffic;');
+    },
+
+    resetNetworkTraffic: function () {
+        browser.executeScript('MockManager.resetTraffic();');
     }
 };
 

--- a/lib/mock-service.js
+++ b/lib/mock-service.js
@@ -75,11 +75,11 @@ var MockService = {
     },
 
     getNetworkTraffic: function() {
-        return browser.executeScript('return MockManager.allTraffic;');
+        return browser.executeScript('return window.MockManager.allTraffic;');
     },
 
     resetNetworkTraffic: function () {
-        browser.executeScript('MockManager.resetTraffic();');
+        browser.executeScript('window.MockManager.resetTraffic();');
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-xmlhttprequest-mock",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Ajax requests mock plugin for protractor (works with Angular >= 2 also)",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
@krisboit First of all, thank you so much for writing `protractor-xmlhttprequest-mock`.  It has been a HUGE help!

Since this mock ties so nicely into XMLHttpRequest, this is a nice way to take advantage of these ties to monitor network traffic.

So doing something using `mock-service -> getNetworkTraffic()` gets me data that looks like this:

![Screen Shot 2020-10-12 at 11 03 39 PM](https://user-images.githubusercontent.com/4729235/95814111-34529600-0cdf-11eb-8f79-056bc0e5c779.png)

Then I can make assertions on requests that get mocked, and requests that don't get mocked from my test code in protractor.

Note:  Sorry for all the extra edits that remove spaces.  I can't get my IDE to stop doing that. :|